### PR TITLE
Add foundational DSP algorithms in Ada

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,49 @@
 # Ada-Programming-Language
 
-This repository is dedicated to collecting useful idioms, patterns, and clean code examples in the Ada programming language.  
-In addition to these features, one of my goals is to implement DSP algorithms in order to compare and observe performance differences between C and Ada.
+This repository collects idioms, patterns, and clean code examples written in Ada. It now includes a small digital signal processing (DSP) toolset that can be used to experiment with real-world algorithms and compare their behaviour with implementations in other languages.
+
+## DSP building blocks
+
+The Ada packages under `src/` implement reusable DSP components:
+
+* `DSP.Types` defines common numeric and complex sample types that are reused across the library.
+* `DSP.Windows` provides Hamming, Hann, and Blackman window coefficient generators that are useful for spectral analysis and FIR filter design.
+* `DSP.Filters.FIR` implements a direct-form finite impulse response filter with streaming sample and block based processing helpers.
+* `DSP.Filters.IIR.Biquad` implements a transposed direct-form II biquad with helpers for low-pass, high-pass, and band-pass design using the RBJ cookbook formulae.
+* `DSP.Transforms.DFT` provides straightforward forward and inverse discrete Fourier transforms that operate on the `Sample_Array` and `Complex_Array` types.
+
+### Example usage
+
+```ada
+with DSP.Filters.FIR;
+with DSP.Filters.IIR.Biquad;
+with DSP.Types;
+
+procedure Demo is
+   use DSP.Types;
+
+   Samples : constant Sample_Array := (1 => 1.0, 2 => 0.0, 3 => 0.0, 4 => -1.0);
+   Filter  : DSP.Filters.FIR.FIR_Filter (Order => 3);
+   Output  : Sample_Array (Samples'Range);
+begin
+   DSP.Filters.FIR.Set_Coefficients
+     (Filter,
+      Coefs => (1 => 0.25, 2 => 0.5, 3 => 0.25));
+
+   DSP.Filters.FIR.Process (Filter, Samples, Output);
+end Demo;
+```
+
+The packages are designed to be composable: feed a window into a filter design routine, cascade multiple biquads, or analyse a signal with the DFT.
+
+## Building
+
+The repository does not prescribe a specific project file. Add the `src/` directory to your GNAT project and compile the required units. For quick experiments you can create a simple project file such as:
+
+```gpr
+project DSP is
+   for Source_Dirs use ("src");
+end DSP;
+```
+
+Compile your test program against this project to exercise the algorithms.

--- a/src/dsp-filters-fir.adb
+++ b/src/dsp-filters-fir.adb
@@ -1,0 +1,64 @@
+package body DSP.Filters.FIR is
+   use DSP.Types;
+
+   procedure Set_Coefficients
+     (Filter : in out FIR_Filter;
+      Coefs  : DSP.Types.Sample_Array)
+   is
+   begin
+      if Coefs'Length /= Filter.Order then
+         raise Constraint_Error with "Coefficient length does not match filter order";
+      end if;
+
+      Filter.Coefficients := Coefs;
+   end Set_Coefficients;
+
+   procedure Reset (Filter : in out FIR_Filter) is
+   begin
+      Filter.Buffer   := (others => 0.0);
+      Filter.Position := 1;
+   end Reset;
+
+   function Process_Sample
+     (Filter : in out FIR_Filter;
+      Input  : DSP.Types.Sample) return DSP.Types.Sample
+   is
+      Accumulator : Sample := 0.0;
+      Index       : Positive := Filter.Position;
+   begin
+      Filter.Buffer (Filter.Position) := Input;
+
+      for Coef_Index in Filter.Coefficients'Range loop
+         Accumulator := Accumulator + Filter.Coefficients (Coef_Index) * Filter.Buffer (Index);
+
+         if Index = 1 then
+            Index := Filter.Order;
+         else
+            Index := Index - 1;
+         end if;
+      end loop;
+
+      if Filter.Position = Filter.Order then
+         Filter.Position := 1;
+      else
+         Filter.Position := Filter.Position + 1;
+      end if;
+
+      return Accumulator;
+   end Process_Sample;
+
+   procedure Process
+     (Filter : in out FIR_Filter;
+      Input  : DSP.Types.Sample_Array;
+      Output : out DSP.Types.Sample_Array)
+   is
+   begin
+      if Input'Length /= Output'Length then
+         raise Constraint_Error with "Input and output buffers must have identical lengths";
+      end if;
+
+      for Index in Input'Range loop
+         Output (Index) := Process_Sample (Filter => Filter, Input => Input (Index));
+      end loop;
+   end Process;
+end DSP.Filters.FIR;

--- a/src/dsp-filters-fir.ads
+++ b/src/dsp-filters-fir.ads
@@ -1,0 +1,24 @@
+with DSP.Types;
+
+package DSP.Filters.FIR is
+   type FIR_Filter (Order : Positive) is tagged record
+      Coefficients : DSP.Types.Sample_Array (1 .. Order) := (others => 0.0);
+      Buffer       : DSP.Types.Sample_Array (1 .. Order) := (others => 0.0);
+      Position     : Positive := 1;
+   end record;
+
+   procedure Set_Coefficients
+     (Filter : in out FIR_Filter;
+      Coefs  : DSP.Types.Sample_Array);
+
+   procedure Reset (Filter : in out FIR_Filter);
+
+   function Process_Sample
+     (Filter : in out FIR_Filter;
+      Input  : DSP.Types.Sample) return DSP.Types.Sample;
+
+   procedure Process
+     (Filter : in out FIR_Filter;
+      Input  : DSP.Types.Sample_Array;
+      Output : out DSP.Types.Sample_Array);
+end DSP.Filters.FIR;

--- a/src/dsp-filters-iir-biquad.adb
+++ b/src/dsp-filters-iir-biquad.adb
@@ -1,0 +1,133 @@
+with Ada.Numerics.Generic_Elementary_Functions;
+
+package body DSP.Filters.IIR.Biquad is
+   use DSP.Types;
+
+   package Math is new Ada.Numerics.Generic_Elementary_Functions (Sample);
+
+   procedure Validate_Parameters
+     (Frequency   : Sample;
+      Q           : Sample;
+      Sample_Rate : Sample) is
+   begin
+      if Sample_Rate <= 0.0 then
+         raise Constraint_Error with "Sample rate must be positive";
+      elsif Frequency <= 0.0 or else Frequency >= Sample_Rate / 2.0 then
+         raise Constraint_Error with "Frequency must be within (0, Sample_Rate / 2)";
+      elsif Q <= 0.0 then
+         raise Constraint_Error with "Q must be positive";
+      end if;
+   end Validate_Parameters;
+
+   procedure Set_Coefficients
+     (Filter : in out Biquad_Filter;
+      Value  : Coefficients) is
+   begin
+      Filter.Coefs := Value;
+   end Set_Coefficients;
+
+   procedure Reset (Filter : in out Biquad_Filter) is
+   begin
+      Filter.State := (others => 0.0);
+   end Reset;
+
+   function Process_Sample
+     (Filter : in out Biquad_Filter;
+      Input  : Sample) return Sample
+   is
+      Y : Sample := Filter.Coefs.B0 * Input + Filter.State.Z1;
+   begin
+      Filter.State.Z1 := Filter.Coefs.B1 * Input + Filter.State.Z2 - Filter.Coefs.A1 * Y;
+      Filter.State.Z2 := Filter.Coefs.B2 * Input - Filter.Coefs.A2 * Y;
+      return Y;
+   end Process_Sample;
+
+   procedure Process
+     (Filter : in out Biquad_Filter;
+      Input  : Sample_Array;
+      Output : out Sample_Array)
+   begin
+      if Input'Length /= Output'Length then
+         raise Constraint_Error with "Input and output buffers must have identical lengths";
+      end if;
+
+      for Index in Input'Range loop
+         Output (Index) := Process_Sample (Filter => Filter, Input => Input (Index));
+      end loop;
+   end Process;
+
+   function Normalize (B0, B1, B2, A0, A1, A2 : Sample) return Coefficients;
+
+   function Normalize (B0, B1, B2, A0, A1, A2 : Sample) return Coefficients is
+      Inv_A0 : constant Sample := 1.0 / A0;
+   begin
+      return (B0 => B0 * Inv_A0,
+              B1 => B1 * Inv_A0,
+              B2 => B2 * Inv_A0,
+              A1 => A1 * Inv_A0,
+              A2 => A2 * Inv_A0);
+   end Normalize;
+
+   function Low_Pass
+     (Frequency    : Sample;
+      Q            : Sample;
+      Sample_Rate  : Sample) return Coefficients
+   is
+      W0    : constant Sample := 2.0 * Math.Pi * Frequency / Sample_Rate;
+      Cos_W : constant Sample := Math.Cos (W0);
+      Sin_W : constant Sample := Math.Sin (W0);
+      Alpha : constant Sample := Sin_W / (2.0 * Q);
+   begin
+      Validate_Parameters (Frequency, Q, Sample_Rate);
+
+      return Normalize
+        (B0 => (1.0 - Cos_W) / 2.0,
+         B1 => 1.0 - Cos_W,
+         B2 => (1.0 - Cos_W) / 2.0,
+         A0 => 1.0 + Alpha,
+         A1 => -2.0 * Cos_W,
+         A2 => 1.0 - Alpha);
+   end Low_Pass;
+
+   function High_Pass
+     (Frequency    : Sample;
+      Q            : Sample;
+      Sample_Rate  : Sample) return Coefficients
+   is
+      W0    : constant Sample := 2.0 * Math.Pi * Frequency / Sample_Rate;
+      Cos_W : constant Sample := Math.Cos (W0);
+      Sin_W : constant Sample := Math.Sin (W0);
+      Alpha : constant Sample := Sin_W / (2.0 * Q);
+   begin
+      Validate_Parameters (Frequency, Q, Sample_Rate);
+
+      return Normalize
+        (B0 => (1.0 + Cos_W) / 2.0,
+         B1 => -(1.0 + Cos_W),
+         B2 => (1.0 + Cos_W) / 2.0,
+         A0 => 1.0 + Alpha,
+         A1 => -2.0 * Cos_W,
+         A2 => 1.0 - Alpha);
+   end High_Pass;
+
+   function Band_Pass
+     (Frequency    : Sample;
+      Q            : Sample;
+      Sample_Rate  : Sample) return Coefficients
+   is
+      W0    : constant Sample := 2.0 * Math.Pi * Frequency / Sample_Rate;
+      Cos_W : constant Sample := Math.Cos (W0);
+      Sin_W : constant Sample := Math.Sin (W0);
+      Alpha : constant Sample := Sin_W / (2.0 * Q);
+   begin
+      Validate_Parameters (Frequency, Q, Sample_Rate);
+
+      return Normalize
+        (B0 => Sin_W / 2.0,
+         B1 => 0.0,
+         B2 => -Sin_W / 2.0,
+         A0 => 1.0 + Alpha,
+         A1 => -2.0 * Cos_W,
+         A2 => 1.0 - Alpha);
+   end Band_Pass;
+end DSP.Filters.IIR.Biquad;

--- a/src/dsp-filters-iir-biquad.ads
+++ b/src/dsp-filters-iir-biquad.ads
@@ -1,0 +1,51 @@
+with DSP.Types;
+
+package DSP.Filters.IIR.Biquad is
+   type Coefficients is record
+      B0 : DSP.Types.Sample := 1.0;
+      B1 : DSP.Types.Sample := 0.0;
+      B2 : DSP.Types.Sample := 0.0;
+      A1 : DSP.Types.Sample := 0.0;
+      A2 : DSP.Types.Sample := 0.0;
+   end record;
+
+   type State is record
+      Z1 : DSP.Types.Sample := 0.0;
+      Z2 : DSP.Types.Sample := 0.0;
+   end record;
+
+   type Biquad_Filter is tagged record
+      Coefs : Coefficients := (B0 => 1.0, others => 0.0);
+      State : State;
+   end record;
+
+   procedure Set_Coefficients
+     (Filter : in out Biquad_Filter;
+      Value  : Coefficients);
+
+   procedure Reset (Filter : in out Biquad_Filter);
+
+   function Process_Sample
+     (Filter : in out Biquad_Filter;
+      Input  : DSP.Types.Sample) return DSP.Types.Sample;
+
+   procedure Process
+     (Filter : in out Biquad_Filter;
+      Input  : DSP.Types.Sample_Array;
+      Output : out DSP.Types.Sample_Array);
+
+   function Low_Pass
+     (Frequency    : DSP.Types.Sample;
+      Q            : DSP.Types.Sample;
+      Sample_Rate  : DSP.Types.Sample) return Coefficients;
+
+   function High_Pass
+     (Frequency    : DSP.Types.Sample;
+      Q            : DSP.Types.Sample;
+      Sample_Rate  : DSP.Types.Sample) return Coefficients;
+
+   function Band_Pass
+     (Frequency    : DSP.Types.Sample;
+      Q            : DSP.Types.Sample;
+      Sample_Rate  : DSP.Types.Sample) return Coefficients;
+end DSP.Filters.IIR.Biquad;

--- a/src/dsp-transforms-dft.adb
+++ b/src/dsp-transforms-dft.adb
@@ -1,0 +1,67 @@
+with Ada.Numerics.Generic_Elementary_Functions;
+
+package body DSP.Transforms.DFT is
+   use DSP.Types;
+
+   package Math is new Ada.Numerics.Generic_Elementary_Functions (Sample);
+
+   function Forward (Input : Sample_Array) return Complex_Array is
+      Result      : Complex_Array (Input'Range);
+      Samples     : constant Sample := Sample (Input'Length);
+      First_Index : constant Positive := Input'First;
+   begin
+      for K in Input'Range loop
+         declare
+            Sum_Re : Sample := 0.0;
+            Sum_Im : Sample := 0.0;
+            K_Pos  : constant Sample := Sample (Integer (K - First_Index));
+         begin
+            for N in Input'Range loop
+               declare
+                  N_Pos   : constant Sample := Sample (Integer (N - First_Index));
+                  Angle   : constant Sample := -2.0 * Math.Pi * K_Pos * N_Pos / Samples;
+                  Cos_A   : constant Sample := Math.Cos (Angle);
+                  Sin_A   : constant Sample := Math.Sin (Angle);
+                  Sample_ : constant Sample := Input (N);
+               begin
+                  Sum_Re := Sum_Re + Sample_ * Cos_A;
+                  Sum_Im := Sum_Im - Sample_ * Sin_A;
+               end;
+            end loop;
+
+            Result (K) := To_Complex (Sum_Re, Sum_Im);
+         end;
+      end loop;
+
+      return Result;
+   end Forward;
+
+   function Inverse (Input : Complex_Array) return Sample_Array is
+      Result      : Sample_Array (Input'Range);
+      Samples     : constant Sample := Sample (Input'Length);
+      First_Index : constant Positive := Input'First;
+   begin
+      for N in Input'Range loop
+         declare
+            Sum : Sample := 0.0;
+            N_Pos  : constant Sample := Sample (Integer (N - First_Index));
+         begin
+            for K in Input'Range loop
+               declare
+                  K_Pos   : constant Sample := Sample (Integer (K - First_Index));
+                  Angle   : constant Sample := 2.0 * Math.Pi * K_Pos * N_Pos / Samples;
+                  Cos_A   : constant Sample := Math.Cos (Angle);
+                  Sin_A   : constant Sample := Math.Sin (Angle);
+                  Value   : constant Complex_Sample := Input (K);
+               begin
+                  Sum := Sum + Value.Re * Cos_A - Value.Im * Sin_A;
+               end;
+            end loop;
+
+            Result (N) := Sum / Samples;
+         end;
+      end loop;
+
+      return Result;
+   end Inverse;
+end DSP.Transforms.DFT;

--- a/src/dsp-transforms-dft.ads
+++ b/src/dsp-transforms-dft.ads
@@ -1,0 +1,6 @@
+with DSP.Types;
+
+package DSP.Transforms.DFT is
+   function Forward (Input : DSP.Types.Sample_Array) return DSP.Types.Complex_Array;
+   function Inverse (Input : DSP.Types.Complex_Array) return DSP.Types.Sample_Array;
+end DSP.Transforms.DFT;

--- a/src/dsp-types.adb
+++ b/src/dsp-types.adb
@@ -1,0 +1,16 @@
+with Ada.Numerics.Generic_Elementary_Functions;
+
+package body DSP.Types is
+   package Math is new Ada.Numerics.Generic_Elementary_Functions (Sample);
+   use Sample_Complex_Types;
+
+   function To_Complex (Re : Sample; Im : Sample := 0.0) return Complex_Sample is
+   begin
+      return (Re => Re, Im => Im);
+   end To_Complex;
+
+   function Magnitude (Value : Complex_Sample) return Sample is
+   begin
+      return Math.Sqrt (Value.Re * Value.Re + Value.Im * Value.Im);
+   end Magnitude;
+end DSP.Types;

--- a/src/dsp-types.ads
+++ b/src/dsp-types.ads
@@ -1,0 +1,14 @@
+with Ada.Numerics.Generic_Complex_Types;
+
+package DSP.Types is
+   type Sample is digits 15;
+   type Sample_Array is array (Positive range <>) of Sample;
+
+   package Sample_Complex_Types is new Ada.Numerics.Generic_Complex_Types (Sample);
+   subtype Complex_Sample is Sample_Complex_Types.Complex;
+   type Complex_Array is array (Positive range <>) of Complex_Sample;
+
+   function To_Complex (Re : Sample; Im : Sample := 0.0) return Complex_Sample;
+
+   function Magnitude (Value : Complex_Sample) return Sample;
+end DSP.Types;

--- a/src/dsp-windows.adb
+++ b/src/dsp-windows.adb
@@ -1,0 +1,42 @@
+with Ada.Numerics.Generic_Elementary_Functions;
+
+package body DSP.Windows is
+   package Math is new Ada.Numerics.Generic_Elementary_Functions (DSP.Types.Sample);
+   use DSP.Types;
+
+   function Window_Value (Length : Positive; Index : Natural; A0, A1, A2 : Sample) return Sample;
+
+   function Window_Value (Length : Positive; Index : Natural; A0, A1, A2 : Sample) return Sample is
+      Denominator : constant Sample := (if Length = 1 then 1.0 else Sample (Length - 1));
+      Argument    : constant Sample := 2.0 * Sample (Index) * Math.Pi / Denominator;
+   begin
+      return A0 - A1 * Math.Cos (Argument) + A2 * Math.Cos (2.0 * Argument);
+   end Window_Value;
+
+   function Hamming (Length : Positive) return Sample_Array is
+      Result : Sample_Array (1 .. Length);
+   begin
+      for I in Result'Range loop
+         Result (I) := Window_Value (Length => Length, Index => I - 1, A0 => 0.54, A1 => 0.46, A2 => 0.0);
+      end loop;
+      return Result;
+   end Hamming;
+
+   function Hann (Length : Positive) return Sample_Array is
+      Result : Sample_Array (1 .. Length);
+   begin
+      for I in Result'Range loop
+         Result (I) := Window_Value (Length => Length, Index => I - 1, A0 => 0.5, A1 => 0.5, A2 => 0.0);
+      end loop;
+      return Result;
+   end Hann;
+
+   function Blackman (Length : Positive) return Sample_Array is
+      Result : Sample_Array (1 .. Length);
+   begin
+      for I in Result'Range loop
+         Result (I) := Window_Value (Length => Length, Index => I - 1, A0 => 0.42, A1 => 0.5, A2 => 0.08);
+      end loop;
+      return Result;
+   end Blackman;
+end DSP.Windows;

--- a/src/dsp-windows.ads
+++ b/src/dsp-windows.ads
@@ -1,0 +1,7 @@
+with DSP.Types;
+
+package DSP.Windows is
+   function Hamming (Length : Positive) return DSP.Types.Sample_Array;
+   function Hann (Length : Positive) return DSP.Types.Sample_Array;
+   function Blackman (Length : Positive) return DSP.Types.Sample_Array;
+end DSP.Windows;


### PR DESCRIPTION
## Summary
- add reusable DSP type definitions, window generators, FIR filters, biquad filters, and DFT implementations in Ada
- document the new DSP modules and provide a usage example in the README

## Testing
- not run (GNAT toolchain is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c8594f3cac83219fac2d710dfe3243